### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/locales-sync.yml
+++ b/.github/workflows/locales-sync.yml
@@ -1,4 +1,6 @@
 name: "Synchronize locales"
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/iezak/londoncards/security/code-scanning/2](https://github.com/iezak/londoncards/security/code-scanning/2)

**General fix strategy:**  
Add an explicit `permissions` field in the workflow YAML to restrict the `GITHUB_TOKEN` to the minimal required permissions for the job(s).

**Single best way to fix:**  
Since this workflow only delegates to a reusable workflow (itself), add a `permissions` block at the root level (just after `name:` or before `on:`) so it applies to all jobs, unless the job or the reusable workflow requires additional permissions. As a minimal starting point, use `contents: read`. If the reusable workflow requires additional write permissions (e.g., to create PRs), they can be added (e.g., `pull-requests: write`). If unsure, start with `contents: read` and update to add more as needed.

**Where to change:**  
Edit `.github/workflows/locales-sync.yml`, add a `permissions:` block after the `name:` field and before (or after) the `on:` field.

**What is needed:**  
No extra methods, imports, or definitions required. Just the addition of a `permissions` section to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
