### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/locales-update-source.yml
+++ b/.github/workflows/locales-update-source.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   push-on-transifex:
     name: "Push locales sources"
+    permissions:
+      contents: read
     uses: "glpi-project/plugin-translation-workflows/.github/workflows/transifex-push-sources.yml@v1"
     secrets:
       transifex-token: "${{ secrets.TRANSIFEX_TOKEN }}"


### PR DESCRIPTION
Potential fix for [https://github.com/iezak/londoncards/security/code-scanning/1](https://github.com/iezak/londoncards/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the job or at the root of the workflow to explicitly restrict GITHUB_TOKEN’s privileges. The minimal permissions needed depend on what actions the called workflow (`transifex-push-sources.yml`) needs—typically, pushing or pulling source changes from the repository may require `contents: read` or `contents: write`, but unless write is confirmed necessary, the default and safest is `contents: read`. Since this job appears to push data to Transifex (via secrets), but does not update the repository itself, `contents: read` is likely sufficient. Place the new `permissions` block at the job definition for `push-on-transifex`. If finer tuning is later needed, adjust the specific permissions as documented by the downstream workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
