### PR TITLE
fix(workflow): update Transifex pull flag and permissions

### DIFF
--- a/.github/workflows/locales-sync.yml
+++ b/.github/workflows/locales-sync.yml
@@ -1,6 +1,7 @@
 name: "Synchronize locales"
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   schedule:

--- a/.github/workflows/transifex-sync.yml
+++ b/.github/workflows/transifex-sync.yml
@@ -45,7 +45,7 @@ jobs:
     - name: "Pull translations"
       uses: "transifex/cli-action@v2"
       with:
-        args: "pull -a --minimum-perc=80 --overwrite"
+        args: "pull --all --minimum-perc=80 --overwrite"
         token: "${{ secrets.transifex-token }}"
 
     - name: "Compile MO files"


### PR DESCRIPTION
## Summary
- use `--all` for Transifex CLI pull command
- grant write permissions in locales sync workflow

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable, indentation: disable}}' .github/workflows/transifex-sync.yml .github/workflows/locales-sync.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b58a188108832fb9ff38c6b224d653